### PR TITLE
Using Alpine package manager and install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM asciidoctor/docker-asciidoctor:latest
 
-RUN dnf install -y asciidoc git && dnf clean packages
+#RUN dnf install -y asciidoc git && dnf clean packages
+RUN apk update && apk upgrade && apk add --no-cache git asciidoc
 RUN git clone https://github.com/mojavelinux/asciidoc-blogpost.py.git /opt/asciidoc-blogpost.py
 RUN asciidoc --backend install /opt/asciidoc-blogpost.py/conf/wordpress.zip
 ENV PATH=/opt/asciidoc-blogpost.py:$PATH


### PR DESCRIPTION
This will fix the issue with `dnf command not found`. Not sure why, but
the current image from asciidoctor uses Alpine Linux as its base.